### PR TITLE
Keep tables with no definitive heading row

### DIFF
--- a/src/tables.js
+++ b/src/tables.js
@@ -32,7 +32,12 @@ rules.tableRow = {
 }
 
 rules.table = {
-  filter: 'table',
+  // Only convert tables with a heading row.
+  // Tables with no heading row are kept using `keep` (see below).
+  filter: function (node) {
+    return node.nodeName === 'TABLE' && isHeadingRow(node.rows[0])
+  },
+
   replacement: function (content) {
     // Ensure there are no blank lines
     content = content.replace('\n\n', '\n')
@@ -85,5 +90,8 @@ function cell (content, node) {
 }
 
 export default function tables (turndownService) {
+  turndownService.keep(function (node) {
+    return node.nodeName === 'TABLE' && !isHeadingRow(node.rows[0])
+  })
   for (var key in rules) turndownService.addRule(key, rules[key])
 }

--- a/test/index.html
+++ b/test/index.html
@@ -151,6 +151,10 @@
 <div class="case" data-name="empty rows">
   <div class="input">
     <table>
+      <thead>
+        <td>Heading 1</td>
+        <td>Heading 2</td>
+      </thead>
       <tbody>
         <tr>
           <td>Row 1</td>
@@ -167,7 +171,9 @@
       </tbody>
     </table>
 </div>
-<pre class="expected">| Row 1 | Row 1 |
+<pre class="expected">| Heading 1 | Heading 2 |
+| --- | --- |
+| Row 1 | Row 1 |
 | Row 3 | Row 3 |</pre>
 </div>
 
@@ -233,23 +239,6 @@
 | Content |</pre>
 </div>
 
-<div class="case" data-name="th in first row">
-  <div class="input">
-    <table>
-      <tr>
-        <th>Heading</th>
-        <td>Not a heading</td>
-      </tr>
-      <tr>
-        <td>Heading</td>
-        <td>Not a heading</td>
-      </tr>
-    </table>
-  </div>
-  <pre class="expected">| Heading | Not a heading |
-| Heading | Not a heading |</pre>
-</div>
-
 <div class="case" data-name="heading cells in both thead and tbody">
   <div class="input">
     <table>
@@ -271,6 +260,32 @@
   </div>
   <pre class="expected">| Heading |
 | --- |</pre>
+</div>
+
+<div class="case" data-name="non-definitive heading row (not converted)">
+  <div class="input">
+    <table>
+      <tr><td>Row 1 Cell 1</td><td>Row 1 Cell 2</td></tr>
+      <tr><td>Row 2 Cell 1</td><td>Row 2 Cell 2</td></tr>
+    </table>
+  </div>
+  <pre class="expected">&lt;table&gt;&lt;tbody&gt;&lt;tr&gt;&lt;td&gt;Row 1 Cell 1&lt;/td&gt;&lt;td&gt;Row 1 Cell 2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Row 2 Cell 1&lt;/td&gt;&lt;td&gt;Row 2 Cell 2&lt;/td&gt;&lt;/tr&gt;&lt;/tbody&gt;&lt;/table&gt;</pre>
+</div>
+
+<div class="case" data-name="non-definitive heading row with th (not converted)">
+  <div class="input">
+    <table>
+      <tr>
+        <th>Heading</th>
+        <td>Not a heading</td>
+      </tr>
+      <tr>
+        <td>Heading</td>
+        <td>Not a heading</td>
+      </tr>
+    </table>
+  </div>
+  <pre class="expected">&lt;table&gt;&lt;tbody&gt;&lt;tr&gt;&lt;th&gt;Heading&lt;/th&gt;&lt;td&gt;Not a heading&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Heading&lt;/td&gt;&lt;td&gt;Not a heading&lt;/td&gt;&lt;/tr&gt;&lt;/tbody&gt;&lt;/table&gt;</pre>
 </div>
 
 <div class="case" data-name="highlighted code block with html">


### PR DESCRIPTION
Closes #4 #7 

Tables without a heading row are currently converted to invalid markdown strings. In cases where it's not possible to determine a heading row*, the table will be kept as HTML.

---

\* A `<tr>` is a "heading" row if:
- the parent is a `THEAD`
- _or_ if its the first child of the `TABLE` or the first` TBODY` (possibly following a blank `THEAD`), and every cell is a `TH`